### PR TITLE
Wombat and Adwaita theme counterpart

### DIFF
--- a/standard-adwaita.el
+++ b/standard-adwaita.el
@@ -1,0 +1,167 @@
+;;; standard-adwaita.el --- Like the built-in adwaita theme, but more consistent  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Free Software Foundation, Inc.
+
+;; Author: Elijah Gabe Pérez <eg642616@gmail.com>
+;; Keywords: faces, theme, accessibility
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; TODO:
+
+;;; Code:
+
+(require 'standard-themes)
+
+(defcustom standard-adwaita-palette-overrides nil
+  "Overrides for `adwaita-palette'."
+  :type '(repeat (list symbol (choice symbol string)))
+  :group 'adwaita-theme)
+
+(defconst standard-adwaita-palette
+  (modus-themes-generate-palette
+   `((bg-main "#EDEDED")
+     (fg-main "#2E3436")
+     (red "#c01c28")
+     (green "#3a944a")
+     (yellow "#c88800")
+     (blue "#3584e4")
+     (magenta "#9841bb")
+     (cyan "#2190a4")
+
+     (bg-tab-bar "#eeeeec")
+     (bg-tab-other "#ffffff")
+
+     (cursor "#00BBFF")
+     (border "#EDEDED")
+     (fringe "#E6E6E6")
+
+     (bg-mode-line-active "white")
+     (fg-mode-line-active "#2E3436")
+     (bg-mode-line-inactive "white")
+     (fg-mode-line-inactive "#C6C6C6")
+
+     (fg-prompt "#0084C8")
+
+     (bg-hl-line "#D9E2EF")
+     (bg-region "#C2D5E9")
+
+     (info "#4E9A06")
+     (warning "#CE5C00")
+     (err "#B50000")
+     (builtin "#A020F0")
+     (constant "#F5666D")
+     (comment "#204A87")
+     (fnname "#00578E")
+     (keyword "#A52A2A")
+     (string "#4E9A06")
+     (type "#2F8B58")
+     (variable "#0084C8")
+     (warning "#F5666D")
+
+     (fg-link "#0066CC")
+     (fg-link-visited "#6799CC")
+
+     (bg-mark-select "#4A90D9")
+     (fg-mark-select "white")
+     (bg-search-lazy "#77A4DD")
+     (fg-search-lazy "white")
+     (bg-hover "#4A90D9")
+
+     (bg-search-current "#77A4DD")
+     (fg-search-current "white")
+
+     (fg-added "#4E9A06")
+     (fg-removed "#F5666D")
+     (bg-added "#eeffee")
+     (bg-removed "#ffeeee")
+
+     (mail-subject   "#FF7092")
+     (mail-cite-0    "#00578E")
+     (mail-cite-1    "#0084C8"))
+   'cool
+   nil
+   (append
+    '((fg-region unspecified)
+      (bg-link unspecified)
+      (bg-link-visited unspecified)
+      (bg-line-number-inactive unspecified)
+      (bg-line-number-active bg-hl-line)
+      (mail-recipient mail-subject))
+    standard-themes-common-palette-mappings)))
+
+(defvar standard-adwaita-custom-faces
+  `(`(dired-header ((,c (:weight bold :foreground "#0084C8"))))
+    ;; `(widget-button ((,c (:weight bold :foreground "#0084C8"))))
+    ;; `(success ((,c (:weight bold :foreground "#4E9A06"))))
+
+    ;; `(highlight ((,c (:foreground "white" :background "#4A90D9"))))
+
+    `(erc-action-face ((,c (:foreground "#F5666D"))))
+    `(erc-button ((,c (:foreground "#A8799C"))))
+    `(erc-current-nick-face ((,c (:weight bold :foreground "#FF7092"))))
+    `(erc-error-face ((,c (:foreground "#F5666D" :weight bold))))
+    `(erc-input-face ((,c (:foreground "black"))))
+    `(erc-keyword-face ((,c (:foreground "#F5666D"))))
+    `(erc-my-nick-face ((,c (:weight bold :foreground "#FF8CA7"))))
+    `(erc-nick-default-face ((,c (:weight bold :foreground "#0084C8"))))
+    `(erc-notice-face ((,c (:foreground "#0084C8"))))
+    `(erc-prompt-face ((,c (:foreground "black"))))
+    `(erc-timestamp-face ((,c (:foreground ,"#4CB64A"))))
+
+    `(magit-log-sha1 ((,c (:foreground "#FF7092"))))
+    `(magit-log-head-label-local ((,c (:foreground "#4F78B5"))))
+    `(magit-log-head-label-remote ((,c (:foreground ,"#4CB64A"))))
+    `(magit-branch ((,c (:weight bold :foreground "#0084C8"))))
+    `(magit-section-title ((,c (:weight bold :foreground "#00578E"))))
+    `(magit-item-highlight ((,c (:background "#FEFFBF"))))
+    `(magit-diff-add ((,c (:weight bold :foreground "#4CB64A"))))
+    `(magit-diff-del ((,c (:bold nil :foreground "#F5666D"))))
+
+    `(gnus-group-mail-1-empty ((,c (:foreground "#00578E"))))
+    `(gnus-group-mail-1 ((,c (:weight bold :foreground "#4F78B5"))))
+    `(gnus-group-mail-3-empty ((,c (:foreground "#00578E"))))
+    `(gnus-group-mail-3 ((,c (:weight bold :foreground "#9CBB43"))))
+    `(gnus-group-news-3-empty ((,c (:foreground "#00578E"))))
+    `(gnus-group-news-3 ((,c (:weight bold :foreground "#9CBB43"))))
+    `(gnus-header-name ((,c (:weight bold :foreground "#0084C8"))))
+    `(gnus-header-subject ((,c (:weight bold :foreground "#FF7092"))))
+    `(gnus-header-content ((,c (:foreground "#FF7092"))))
+    `(gnus-button ((,c (:weight bold :foreground "#00578E"))))
+    `(gnus-cite-1 ((,c (:foreground "#00578E"))))
+    `(gnus-cite-2 ((,c (:foreground "#0084C8"))))
+
+    `(image-dired-thumb-mark ((,c (:background "#CE5C00"))))
+    `(image-dired-thumb-flagged ((,c (:background "#B50000"))))
+
+    ;; `(diff-added ((,c (:weight bold :foreground "#4E9A06"))))
+    ;; `(diff-removed ((,c (:weight bold :foreground "#F5666D"))))
+    ))
+
+(modus-themes-theme
+ 'standard-adwaita
+ 'standard-themes
+ "Like the built-in adwaita theme, but more consistent"
+ 'light
+ 'modus-themes-operandi-palette
+ 'standard-adwaita-palette
+ 'standard-adwaita-palette-overrides
+ 'standard-adwaita-custom-faces)
+
+(provide 'standard-adwaita)
+;;; standard-adwaita.el ends here

--- a/standard-themes.el
+++ b/standard-themes.el
@@ -60,11 +60,11 @@ if you prefer to blend Standard and Modus into a single group, enable
   :tag "Standard Themes")
 
 (defconst standard-themes-light-themes
-  '(standard-light standard-light-tinted)
+  '(standard-light standard-light-tinted standard-adwaita)
   "List of symbols with the light Standard themes.")
 
 (defconst standard-themes-dark-themes
-  '(standard-dark standard-dark-tinted)
+  '(standard-dark standard-dark-tinted standard-wombat)
   "List of symbols with the dark Standard themes.")
 
 (defvaralias 'standard-themes-collection 'standard-themes-items
@@ -183,7 +183,9 @@ if you prefer to blend Standard and Modus into a single group, enable
   '((standard-light standard-themes "Like the unthemed light Emacs, but more consistent." light standard-light-palette nil standard-light-palette-overrides)
     (standard-light-tinted standard-themes "Light ochre variant of the standard-light theme." light standard-light-tinted-palette nil standard-light-tinted-palette-overrides)
     (standard-dark standard-themes "Like the unthemed dark Emacs, but more consistent." dark standard-dark-palette nil standard-dark-palette-overrides)
-    (standard-dark-tinted standard-themes "Night sky variant of standard-dark theme." dark standard-dark-tinted-palette nil standard-dark-tinted-palette-overrides)))
+    (standard-dark-tinted standard-themes "Night sky variant of standard-dark theme." dark standard-dark-tinted-palette nil standard-dark-tinted-palette-overrides)
+    (standard-adwaita standard-themes "Like the built-in adwaita theme, but more consistent" light standard-adwaita-palette nil standard-adwaita-palette-overrides)
+    (standard-wombat standard-themes "Like the built-in adwaita theme, but more consistent" dark standard-wombat-palette nil standard-wombat-palette-overrides)))
 
 (defvar standard-themes--declared-p nil)
 

--- a/standard-wombat.el
+++ b/standard-wombat.el
@@ -1,0 +1,170 @@
+;;; standard-wombat.el --- Like the built-in wombat theme, but more consistent  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2026 Free Software Foundation, Inc.
+
+;; Author: Elijah Gabe Pérez <eg642616@gmail.com>
+;; Keywords: faces, theme, accessibility
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; TODO:
+
+;;; Code:
+
+(require 'standard-themes)
+
+(defconst standard-wombat-palette
+  (modus-themes-generate-palette
+   '((bg-main "#242424")
+     (fg-main "#f6f3e8")
+     (fg-dim "#99968b") ; (?)
+     (red "#e5786d") ; or "#b85149"
+     (green "#92a65e") ; or "#cae982" or "#95e454"
+     (yellow "#ddaa6f") ; or "#edc4a3" or "#ccaa8f"
+     (yellow-faint "#ccaa8f") ; (?)
+     (blue "#8ac6f2") ; or "#5b98c2" or "#333366"
+     (magenta "#a6a1de") ; or "#64619a"
+     (cyan "#70cecc") ; or "#3f9f9e"
+
+     (cursor "#656565")
+     (fringe "#303030")
+     (border "#303030")
+
+     (bg-search-current "#343434")
+     (fg-search-current "#857b6f")
+
+     (bg-hover "#333333")
+     (bg-hover-secondary "#333366")
+     (bg-hl-line "#404040")
+     (bg-region "#4f4f4f")
+
+     (bg-mode-line-active "#444444")
+     (fg-mode-line-active "#f6f3e8")
+     (fg-mode-line-inactive "#857b6f")
+
+     (bg-tab-bar "#303030")
+
+     (fg-link "#8ac6f2")
+     (fg-link-visited "#e5786d")
+
+     (fg-prompt "#e5786d")
+
+     (comment "#99968b")
+     (constant "#e5786d")
+     (keyword "#8ac6f2")
+     (string "#95e454")
+     (docstring "#cae982")
+     (type "#92a65e")
+     (variable "#cae682")
+     (warning "#ff9900")
+     (info "#95e454")
+
+     (keybind "#ddaa6f")
+
+     (mail-subject "#cae682")
+     (mail-recipient "#95e454")
+     (mail-cite-0 "#99968b")
+     (mail-cite-1 "#92a65e")
+     (mail-cite-2 "#ddaa6f")
+     (mail-cite-3 "#ff9900")
+     (mail-other "#95e454")
+
+     (bg-button-active "#333333")
+     (fg-button-active "#f6f3e8")
+
+     (bg-mark-select "#333366")
+     (bg-search-lazy "#384048")
+     (fg-search-lazy "#a0a8b0"))
+   'warm
+   nil
+   (append
+    '((bg-line-number-inactive unspecified)
+      (bg-line-number-active bg-hl-line)
+      (fg-region unspecified)
+      (bg-link unspecified)
+      (underline-link fg-link)
+      (bg-link-visited unspecified)
+      (underline-link-visited fg-link-visited)
+      (bg-line-number-inactive unspecified)
+      (bg-line-number-active bg-hl-line)
+      (builtin constant)
+      (preprocessor constant)
+      (fnname variable)
+      (fnname-call fnname)
+      (mail-recipient mail-subject)
+      (fg-mark-select fg-main))
+    standard-themes-common-palette-mappings)))
+
+(defcustom standard-wombat-palette-overrides nil
+  "Overrides for `standard-wombat-palette'."
+  :type '(repeat (list symbol (choice symbol string)))
+  :group 'wombat-theme)
+
+;; Extracted from wombat-theme.el,
+;; override some faces which exclusive from wombat-theme.el.
+(defvar standard-wombat-custom-faces
+  `(`(hl-line ((,c (:background ,bg-hl-line :underline (:color ,fg-dim :style line :position t)))))
+    `(highlight ((,c (:background "#454545" :foreground "#ffffff" :underline t))))
+    `(mode-line ((,c (:inherit modus-themes-ui-variable-pitch
+                               :background ,bg-mode-line-active
+                               :foreground ,fg-mode-line-active
+                               :box nil))))
+    `(mode-line-inactive ((,c (:inherit modus-themes-ui-variable-pitch
+                                        :background ,bg-mode-line-inactive
+                                        :foreground ,fg-mode-line-inactive
+                                        :box nil))))
+    `(homoglyph ((,c (:foreground "#ddaa6f" :weight bold))))
+    `(help-key-binding ((,c (:background "#333333" :foreground "#f6f3e8"))))
+    `(header-line ((,c (:background "#303030" :foreground "#e7f6da"))))
+    `(gnus-group-news-1-low ((,c (:foreground "#95e454"))))
+    `(gnus-group-news-2 ((,c (:weight bold :foreground "#cae682"))))
+    `(gnus-group-news-2-low ((,c (:foreground "#cae682"))))
+    ;; `(gnus-group-news-3 ((,c (:weight bold :foreground "#ccaa8f"))))
+    `(gnus-group-news-3-low ((,c (:foreground "#ccaa8f"))))
+    `(gnus-group-news-4 ((,c (:weight bold :foreground "#99968b"))))
+    `(gnus-group-news-4-low ((,c (:foreground "#99968b"))))
+    `(gnus-group-news-5 ((,c (:weight bold :foreground "#cae682"))))
+    `(gnus-group-news-5-low ((,c (:foreground "#cae682"))))
+    ;; `(gnus-group-news-low ((,c (:foreground "#99968b"))))
+    `(gnus-group-mail-1 ((,c (:weight bold :foreground "#95e454"))))
+    `(gnus-group-mail-1-low ((,c (:foreground "#95e454"))))
+    `(gnus-group-mail-2 ((,c (:weight bold :foreground "#cae682"))))
+    `(gnus-group-mail-2-low ((,c (:foreground "#cae682"))))
+    `(gnus-group-mail-3 ((,c (:weight bold :foreground "#ccaa8f"))))
+    `(gnus-group-mail-3-low ((,c (:foreground "#ccaa8f"))))
+    `(gnus-group-mail-low ((,c (:foreground "#99968b"))))
+    `(gnus-header-content ((,c (:foreground "#8ac6f2"))))
+    ;; `(gnus-header-from ((,c (:weight bold :foreground "#95e454"))))
+    ;; `(gnus-header-subject ((,c (:foreground "#cae682"))))
+    `(gnus-header-name ((,c (:foreground "#8ac6f2"))))
+    `(gnus-header-newsgroups ((,c (:foreground "#cae682"))))
+    `(message-header-name ((,c (:foreground "#8ac6f2" :weight bold))))
+    `(message-separator ((,c (:foreground "#e5786d" :weight bold))))))
+
+(modus-themes-theme
+ 'standard-wombat
+ 'standard-themes
+ "Like the built-in wombat theme, but more consistent."
+ 'dark
+ 'modus-themes-vivendi-palette
+ 'standard-wombat-palette
+ 'standard-wombat-palette-overrides
+ 'standard-wombat-custom-faces)
+
+(provide 'standard-wombat)
+;;; standard-wombat.el ends here


### PR DESCRIPTION
These are themes from the thread in bug-gnu-emacs.

~~They are not finished (the color palette needs to be completed), but I am releasing this in case there is interest in having these themes in standard-themes (also to perhaps a little help with the color palette).~~

Screenshots:

standard-wombat:
<img width="1113" height="531" alt="Captura desde 2026-01-08 20-28-36" src="https://github.com/user-attachments/assets/1e1a7af1-94d1-49a0-aa26-1a82c59bcdd0" />


Comparation with wombat:
<img width="1120" height="503" alt="Captura desde 2026-01-08 20-32-02" src="https://github.com/user-attachments/assets/d0ba8561-9bdb-4b7d-91b5-4095ecd4644d" />


---

standard-adwaita:
<img width="987" height="515" alt="Captura desde 2026-01-08 20-38-45" src="https://github.com/user-attachments/assets/0a0cfef0-1597-40a3-8a4c-529a57785cc7" />

Comparation with adwaita:
<img width="1017" height="534" alt="Captura desde 2026-01-08 20-40-44" src="https://github.com/user-attachments/assets/9cb26144-ae4d-482f-b7ed-ff986a7116cb" />

